### PR TITLE
List formats in banlist page programmatically

### DIFF
--- a/app/components/banlist/tabs.hbs
+++ b/app/components/banlist/tabs.hbs
@@ -1,34 +1,15 @@
 <div class="card flex-grow-1" id="nav-main-content">
   <div class="card-header">
     <ul class="nav nav-tabs nav-fill card-header-tabs">
-      <li class="nav-item">
-        {{!-- <a
-          href="#"
-          role="button"
-          class="nav-link {{if (eq this.tab 'startup') 'active'}}"
-          {{on "click" (fn this.setTab "startup")}}
-        >Startup</a> --}}
-        <LinkTo
-          class="nav-link"
-          @route="page.banlists"
-          @query={{hash format="startup"}}
-        >Startup</LinkTo>
-      </li>
-      <li class="nav-item">
-
-        <LinkTo
-          class="nav-link"
-          @route="page.banlists"
-          @query={{hash format="standard"}}
-        >Standard</LinkTo>
-      </li>
-      <li class="nav-item">
-        <LinkTo
-          class="nav-link"
-          @route="page.banlists"
-          @query={{hash format="eternal"}}
-        >Eternal</LinkTo>
-      </li>
+      {{#each @formats as |format|}}
+        <li class="nav-item">
+          <LinkTo
+            class="nav-link"
+            @route="page.banlists"
+            @query={{hash format=format.id}}
+          >{{format.name}}</LinkTo>
+        </li>
+      {{/each}}
     </ul>
   </div>
   <div class="card-body">


### PR DESCRIPTION
I'm opening this PR for a little discussin.
Instead of manually coding the list of formats in the banlist, I was thinking of listing programmatically. This way if we change the name of a format, or remove/add one, it would be less work for us.
There's a slight hitch though, there's no way to auto-sort them so they would display in a different order from the one in currrent NetrunnerDB. Do we want to make them sortable, do we not care, do we just do the listing manually?

![image](https://github.com/NetrunnerDB/NRDBv2/assets/32344/e938eaeb-4f94-4af8-94f0-b872f6910f53)

This is the order it would show with the changes in this PR. I assume it's the order the API sends them in.