### PR TITLE
Link to cycle card list from Format page.

### DIFF
--- a/app/components/format/summary.gjs
+++ b/app/components/format/summary.gjs
@@ -59,7 +59,7 @@ import { eq, formatDate } from '../../utils/template-operators';
         as |cycle|
       }}
         <li>
-          <a href="#">{{cycle.name}}</a>
+          <LinkTo @route="page.cycle" @model="{{ cycle.id }}" >{{cycle.name}}</LinkTo>
         </li>
       {{/each}}
     </ul>


### PR DESCRIPTION
For the card pool display on the formats page, link to the cycles.

That area still needs to handle incomplete cycles.