### PR TITLE
Format banlist nicely

### DIFF
--- a/app/components/banlist/tabs.gjs
+++ b/app/components/banlist/tabs.gjs
@@ -31,40 +31,143 @@ import formatDate from '../../helpers/format-date';
               @expandFirstItem={{true}}
               @items={{format.restrictions}}
             >
-              <:default as |Panel item|>
+              <:default as |Panel restriction|>
                 <Panel>
+                  {{! each restriction}}
                   <:title>
-                    {{item.name}}
+                    {{restriction.name}}
                   </:title>
                   <:subtitle>
-                    {{item.size}}
+                    {{restriction.obj.size}}
                     cards. Start Date:
-                    {{(formatDate item.dateStart)}}.
+                    {{(formatDate restriction.obj.dateStart)}}.
                   </:subtitle>
                   <:body>
                     <div class="row">
                       <div class="col-6">
                         <h3>Corp Cards</h3>
+                        {{#if restriction.obj.verdicts.banned.length }}
                         <ul>
                           <li>
                             <strong>Banned</strong>
                             <ul>
-                              {{#each item.verdicts.banned as |banned|}}
+                              {{#each restriction.corp.banned as |banned|}}
                                 <li>
                                   <CardLinkTo
-                                    @id={{banned}}
+                                    @printing={{banned}}
                                     class="text-truncate"
                                   >
-                                    {{banned}}
+                                    {{banned.title}}
                                   </CardLinkTo>
                                 </li>
                               {{/each}}
                             </ul>
                           </li>
                         </ul>
+                        {{/if}}
+
+                        {{#if restriction.obj.verdicts.restricted.length }}
+                        <ul>
+                          <li>
+                            <strong>Restricted</strong>
+                            <ul>
+                              {{#each restriction.corp.restricted as |restricted|}}
+                                <li>
+                                  <CardLinkTo
+                                    @printing={{restricted}}
+                                    class="text-truncate"
+                                  >
+                                    {{restricted.title}}
+                                  </CardLinkTo>
+                                </li>
+                              {{/each}}
+                            </ul>
+                          </li>
+                        </ul>
+                        {{/if}}
+
+                        {{#if restriction.obj.verdicts.global_penalty.length }}
+                        <ul>
+                          <li>
+                            <strong>Global Penalty</strong>
+                            <ul>
+                              {{#each restriction.corp.global_penalty as |global_penalty|}}
+                                <li>
+                                  <CardLinkTo
+                                    @printing={{global_penalty}}
+                                    class="text-truncate"
+                                  >
+                                    {{global_penalty.title}}
+                                  </CardLinkTo>
+                                </li>
+                              {{/each}}
+                            </ul>
+                          </li>
+                        </ul>
+                        {{/if}}
                       </div>
+
                       <div class="col-6">
                         <h3>Runner Cards</h3>
+                        {{#if restriction.obj.verdicts.banned.length }}
+                        <ul>
+                          <li>
+                            <strong>Banned</strong>
+                            <ul>
+                              {{#each restriction.runner.banned as |banned|}}
+                                <li>
+                                  <CardLinkTo
+                                    @printing={{banned}}
+                                    class="text-truncate"
+                                  >
+                                    {{banned.title}}
+                                  </CardLinkTo>
+                                </li>
+                              {{/each}}
+                            </ul>
+                          </li>
+                        </ul>
+                        {{/if}}
+
+                        {{#if restriction.obj.verdicts.restricted.length }}
+                        <ul>
+                          <li>
+                            <strong>Restricted</strong>
+                            <ul>
+                              {{#each restriction.runner.restricted as |restricted|}}
+                                <li>
+                                  <CardLinkTo
+                                    @printing={{restricted}}
+                                    class="text-truncate"
+                                  >
+                                    {{restricted.title}}
+                                  </CardLinkTo>
+                                </li>
+                              {{/each}}
+                            </ul>
+                          </li>
+                        </ul>
+                        {{/if}}
+
+                        {{#if restriction.obj.verdicts.global_penalty.length }}
+                        <ul>
+                          <li>
+                            <strong>Global Penalty</strong>
+                            <ul>
+                              {{#each restriction.runner.global_penalty as |global_penalty|}}
+                                <li>
+                                  <CardLinkTo
+                                    @printing={{global_penalty}}
+                                    class="text-truncate"
+                                  >
+                                    {{global_penalty.title}}
+                                  </CardLinkTo>
+                                </li>
+                              {{/each}}
+                            </ul>
+                          </li>
+                        </ul>
+                        {{/if}}
                       </div>
                     </div>
                   </:body>

--- a/app/components/banlist/tabs.gjs
+++ b/app/components/banlist/tabs.gjs
@@ -105,6 +105,106 @@ import formatDate from '../../helpers/format-date';
                           </li>
                         </ul>
                         {{/if}}
+
+                        {{#if restriction.hasPoints }}
+                        <ul>
+                          <li>
+                            <strong>Points</strong>
+                            <ul>
+                              <li>
+                                <strong>3 Points</strong>
+                                <ul>
+                                  {{#each restriction.corp.threePoints as |card|}}
+                                    <li>
+                                      <CardLinkTo
+                                        @printing={{card}}
+                                        class="text-truncate"
+                                      >
+                                        {{card.title}}
+                                      </CardLinkTo>
+                                    </li>
+                                  {{/each}}
+                                </ul>
+                              </li>
+                              <li>
+                                <strong>2 Points</strong>
+                                <ul>
+                                  {{#each restriction.corp.twoPoints as |card|}}
+                                    <li>
+                                      <CardLinkTo
+                                        @printing={{card}}
+                                        class="text-truncate"
+                                      >
+                                        {{card.title}}
+                                      </CardLinkTo>
+                                    </li>
+                                  {{/each}}
+                                </ul>
+                              </li>
+                              <li>
+                                <strong>1 Point</strong>
+                                <ul>
+                                  {{#each restriction.corp.onePoint as |card|}}
+                                    <li>
+                                      <CardLinkTo
+                                        @printing={{card}}
+                                        class="text-truncate"
+                                      >
+                                        {{card.title}}
+                                      </CardLinkTo>
+                                    </li>
+                                  {{/each}}
+                                </ul>
+                              </li>
+                            </ul>
+                          </li>
+                        </ul>
+                        {{/if}}
+
+                        {{#if restriction.hasUniversalInfluence }}
+                        <ul>
+                          <li>
+                            <strong>Universal Influence</strong>
+                            <ul>
+                              {{#if restriction.corp.threeUniversalInfluence.length }}
+                              <li>
+                                <strong>3 Influence</strong>
+                                <ul>
+                                  {{#each restriction.corp.threeUniversalInfluence as |card|}}
+                                    <li>
+                                      <CardLinkTo
+                                        @printing={{card}}
+                                        class="text-truncate"
+                                      >
+                                        {{card.title}}
+                                      </CardLinkTo>
+                                    </li>
+                                  {{/each}}
+                                </ul>
+                              </li>
+                              {{/if}}
+                              {{#if restriction.corp.oneUniversalInfluence.length }}
+                              <li>
+                                <strong>1 Universal Influence</strong>
+                                <ul>
+                                  {{#each restriction.corp.oneUniversalInfluence as |card|}}
+                                    <li>
+                                      <CardLinkTo
+                                        @printing={{card}}
+                                        class="text-truncate"
+                                      >
+                                        {{card.title}}
+                                      </CardLinkTo>
+                                    </li>
+                                  {{/each}}
+                                </ul>
+                              </li>
+                              {{/if}}
+                            </ul>
+                          </li>
+                        </ul>
+                        {{/if}}
+
                       </div>
 
                       <div class="col-6">
@@ -168,6 +268,106 @@ import formatDate from '../../helpers/format-date';
                           </li>
                         </ul>
                         {{/if}}
+
+                        {{#if restriction.hasPoints }}
+                        <ul>
+                          <li>
+                            <strong>Points</strong>
+                            <ul>
+                              <li>
+                                <strong>3 Points</strong>
+                                <ul>
+                                  {{#each restriction.runner.threePoints as |card|}}
+                                    <li>
+                                      <CardLinkTo
+                                        @printing={{card}}
+                                        class="text-truncate"
+                                      >
+                                        {{card.title}}
+                                      </CardLinkTo>
+                                    </li>
+                                  {{/each}}
+                                </ul>
+                              </li>
+                              <li>
+                                <strong>2 Points</strong>
+                                <ul>
+                                  {{#each restriction.runner.twoPoints as |card|}}
+                                    <li>
+                                      <CardLinkTo
+                                        @printing={{card}}
+                                        class="text-truncate"
+                                      >
+                                        {{card.title}}
+                                      </CardLinkTo>
+                                    </li>
+                                  {{/each}}
+                                </ul>
+                              </li>
+                              <li>
+                                <strong>1 Point</strong>
+                                <ul>
+                                  {{#each restriction.runner.onePoint as |card|}}
+                                    <li>
+                                      <CardLinkTo
+                                        @printing={{card}}
+                                        class="text-truncate"
+                                      >
+                                        {{card.title}}
+                                      </CardLinkTo>
+                                    </li>
+                                  {{/each}}
+                                </ul>
+                              </li>
+                            </ul>
+                          </li>
+                        </ul>
+                        {{/if}}
+
+                        {{#if restriction.hasUniversalInfluence }}
+                        <ul>
+                          <li>
+                            <strong>Universal Influence</strong>
+                            <ul>
+                              {{#if restriction.runner.threeUniversalInfluence.length }}
+                              <li>
+                                <strong>3 Influence</strong>
+                                <ul>
+                                  {{#each restriction.runner.threeUniversalInfluence as |card|}}
+                                    <li>
+                                      <CardLinkTo
+                                        @printing={{card}}
+                                        class="text-truncate"
+                                      >
+                                        {{card.title}}
+                                      </CardLinkTo>
+                                    </li>
+                                  {{/each}}
+                                </ul>
+                              </li>
+                              {{/if}}
+                              {{#if restriction.runner.oneUniversalInfluence.length }}
+                              <li>
+                                <strong>1 Universal Influence</strong>
+                                <ul>
+                                  {{#each restriction.runner.oneUniversalInfluence as |card|}}
+                                    <li>
+                                      <CardLinkTo
+                                        @printing={{card}}
+                                        class="text-truncate"
+                                      >
+                                        {{card.title}}
+                                      </CardLinkTo>
+                                    </li>
+                                  {{/each}}
+                                </ul>
+                              </li>
+                              {{/if}}
+                            </ul>
+                          </li>
+                        </ul>
+                        {{/if}}
+
                       </div>
                     </div>
                   </:body>

--- a/app/components/banlist/tabs.gjs
+++ b/app/components/banlist/tabs.gjs
@@ -51,6 +51,12 @@ import formatDate from '../../helpers/format-date';
                           <li>
                             <strong>Banned</strong>
                             <ul>
+                              {{#if restriction.banned_subtype.length }}
+                                {{! TODO: have those cards here, but collapsed by default }}
+                                <li>
+                                All Cards With Subtype: <strong>{{ restriction.formatted_banned_subtype }}</strong>
+                                </li>
+                              {{/if}}
                               {{#each restriction.corp.banned as |banned|}}
                                 <li>
                                   <CardLinkTo
@@ -214,6 +220,12 @@ import formatDate from '../../helpers/format-date';
                           <li>
                             <strong>Banned</strong>
                             <ul>
+                              {{#if restriction.banned_subtype.length }}
+                                {{! TODO: have those cards here, but collapsed by default }}
+                                <li>
+                                All Cards With Subtype: <strong>{{ restriction.formatted_banned_subtype }}</strong>
+                                </li>
+                              {{/if}}
                               {{#each restriction.runner.banned as |banned|}}
                                 <li>
                                   <CardLinkTo

--- a/app/routes/page/banlists.js
+++ b/app/routes/page/banlists.js
@@ -1,15 +1,154 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-// import RSVP from 'rsvp';
+import RSVP from 'rsvp';
 
 export default class PageBanlistsRoute extends Route {
   @service store;
 
   async model() {
-    return await Promise.all([
+    let loadedFormats = await Promise.all([
       this.store.findRecord('format', 'startup', { include: 'restrictions' }),
       this.store.findRecord('format', 'standard', { include: 'restrictions' }),
       this.store.findRecord('format', 'eternal', { include: 'restrictions' }),
     ]);
+
+    const cardIds = new Set();
+    const formats = [];
+    loadedFormats.forEach((format) => {
+      const f = {
+        id: format.id,
+        name: format.name,
+        obj: format,
+        restrictions: [],
+      };
+      formats.push(f);
+      format.restrictions.forEach((restriction) => {
+        f['restrictions'].push({
+          id: restriction.id,
+          name: restriction.name,
+          obj: restriction,
+          dateStart: restriction.dateStart,
+          corp: {
+            banned: [],
+            restricted: [],
+            global_penalty: [],
+            points: {},
+            universal_influence: {},
+          },
+          runner: {
+            banned: [],
+            restricted: [],
+            global_penalty: [],
+            points: {},
+            universal_influence: {},
+          },
+        });
+        restriction.verdicts.banned.forEach((cardId) => {
+          cardIds.add(cardId);
+        });
+        restriction.verdicts.restricted.forEach((cardId) => {
+          cardIds.add(cardId);
+        });
+        restriction.verdicts.global_penalty.forEach((cardId) => {
+          cardIds.add(cardId);
+        });
+        for (let cardId in restriction.verdicts.points) {
+          cardIds.add(cardId);
+        }
+        for (let cardId in restriction.verdicts.universal_faction_cost) {
+          cardIds.add(cardId);
+        }
+      });
+    });
+    let cardsQuery = await this.store.query('printing', {
+      filter: {
+        card_id: Array.from(cardIds.keys()).sort().join(','),
+        distinct_cards: true,
+      },
+      include: ['card', 'card_set', 'card_type', 'faction'],
+      page: { limit: 2000 },
+    });
+
+    const cards = new Map();
+    cardsQuery.forEach((c) => {
+      cards.set(c.cardId, c);
+    });
+
+    // Populate the nice versions (TODO: make a better comment)
+    formats.forEach((f) => {
+      f.restrictions.forEach((r) => {
+        r.obj.verdicts['banned'].forEach((b) => {
+          const card = cards.get(b);
+          if (card.sideId == 'corp') {
+            r.corp['banned'].push(card);
+          } else if (card.sideId == 'runner') {
+            r.runner['banned'].push(card);
+          }
+        });
+        r.obj.verdicts['restricted'].forEach((b) => {
+          const card = cards.get(b);
+          if (card.sideId == 'corp') {
+            r.corp['restricted'].push(card);
+          } else if (card.sideId == 'runner') {
+            r.runner['restricted'].push(card);
+          }
+        });
+        r.obj.verdicts['global_penalty'].forEach((b) => {
+          const card = cards.get(b);
+          if (card.sideId == 'corp') {
+            r.corp['global_penalty'].push(card);
+          } else if (card.sideId == 'runner') {
+            r.runner['global_penalty'].push(card);
+          }
+        });
+      });
+    });
+
+    /** Desired Data structure:
+     formats = []
+       'standard' => {
+          'obj' => loadedThing,
+          'restrictions' => [
+            {
+              'obj' => loadedThing,
+              'corp' => {
+                'banned' => [list of cards],
+                'restricted' => [list of cards],
+                'global_penalty' => [list of cards],
+                'points' => {
+                  '1' => [list of cards],
+                  '2' => [list of cards],
+                  '3' => [list of cards]
+                },
+                'universal_influence' => {
+                  '1' => [list of cards],
+                  '2' => [list of cards],
+                  '3' => [list of cards]
+                },
+              },
+              'runner' => {
+                'banned' => [list of cards],
+                'restricted' => [list of cards],
+                'global_penalty' => [list of cards],
+                'points' => {
+                  '1' => [list of cards],
+                  '2' => [list of cards],
+                  '3' => [list of cards]
+                },
+                'universal_influence' => {
+                  '1' => [list of cards],
+                  '2' => [list of cards],
+                  '3' => [list of cards]
+                },
+              },
+            }
+          ]
+       },
+
+    */
+    return RSVP.hash({
+      formats: formats,
+      cards: cardsQuery,
+    });
   }
 }

--- a/app/routes/page/banlists.js
+++ b/app/routes/page/banlists.js
@@ -28,19 +28,27 @@ export default class PageBanlistsRoute extends Route {
           name: restriction.name,
           obj: restriction,
           dateStart: restriction.dateStart,
+          hasPoints: false,
+          hasUniversalInfluence: false,
           corp: {
             banned: [],
             restricted: [],
             global_penalty: [],
-            points: {},
-            universal_influence: {},
+            onePoint: [],
+            twoPoints: [],
+            threePoints: [],
+            oneUniversalInfluence: [],
+            threeUniversalInfluence: [],
           },
           runner: {
             banned: [],
             restricted: [],
             global_penalty: [],
-            points: {},
-            universal_influence: {},
+            onePoint: [],
+            twoPoints: [],
+            threePoints: [],
+            oneUniversalInfluence: [],
+            threeUniversalInfluence: [],
           },
         });
         restriction.verdicts.banned.forEach((cardId) => {
@@ -101,51 +109,49 @@ export default class PageBanlistsRoute extends Route {
             r.runner['global_penalty'].push(card);
           }
         });
+        for (let cardId in r.obj.verdicts.points) {
+          r.hasPoints = true;
+          let card = cards.get(cardId);
+          let points = r.obj.verdicts.points[cardId];
+          if (card.sideId == 'corp') {
+            if (points == 1) {
+              r.corp.onePoint.push(card);
+            } else if (points == 2) {
+              r.corp.twoPoints.push(card);
+            } else if (points == 3) {
+              r.corp.threePoints.push(card);
+            }
+          } else if (card.sideId == 'runner') {
+            if (points == 1) {
+              r.runner.onePoint.push(card);
+            } else if (points == 2) {
+              r.runner.twoPoints.push(card);
+            } else if (points == 3) {
+              r.runner.threePoints.push(card);
+            }
+          }
+        }
+        for (let cardId in r.obj.verdicts.universal_faction_cost) {
+          r.hasUniversalInfluence = true;
+          let card = cards.get(cardId);
+          let cost = r.obj.verdicts.universal_faction_cost[cardId];
+          if (card.sideId == 'corp') {
+            if (cost == 1) {
+              r.corp.oneUniversalInfluence.push(card);
+            } else if (cost == 3) {
+              r.corp.threeUniversalInfluence.push(card);
+            }
+          } else if (card.sideId == 'runner') {
+            if (cost == 1) {
+              r.runner.oneUniversalInfluence.push(card);
+            } else if (cost == 3) {
+              r.runner.threeUniversalInfluence.push(card);
+            }
+          }
+        }
       });
     });
 
-    /** Desired Data structure:
-     formats = []
-       'standard' => {
-          'obj' => loadedThing,
-          'restrictions' => [
-            {
-              'obj' => loadedThing,
-              'corp' => {
-                'banned' => [list of cards],
-                'restricted' => [list of cards],
-                'global_penalty' => [list of cards],
-                'points' => {
-                  '1' => [list of cards],
-                  '2' => [list of cards],
-                  '3' => [list of cards]
-                },
-                'universal_influence' => {
-                  '1' => [list of cards],
-                  '2' => [list of cards],
-                  '3' => [list of cards]
-                },
-              },
-              'runner' => {
-                'banned' => [list of cards],
-                'restricted' => [list of cards],
-                'global_penalty' => [list of cards],
-                'points' => {
-                  '1' => [list of cards],
-                  '2' => [list of cards],
-                  '3' => [list of cards]
-                },
-                'universal_influence' => {
-                  '1' => [list of cards],
-                  '2' => [list of cards],
-                  '3' => [list of cards]
-                },
-              },
-            }
-          ]
-       },
-
-    */
     return RSVP.hash({
       formats: formats,
       cards: cardsQuery,

--- a/app/routes/page/banlists.js
+++ b/app/routes/page/banlists.js
@@ -6,11 +6,11 @@ export default class PageBanlistsRoute extends Route {
   @service store;
 
   async model() {
-    let loadedFormats = await Promise.all([
-      this.store.findRecord('format', 'startup', { include: 'restrictions' }),
-      this.store.findRecord('format', 'standard', { include: 'restrictions' }),
-      this.store.findRecord('format', 'eternal', { include: 'restrictions' }),
-    ]);
+    let loadedFormats = await this.store.query('format', {
+      filter: { id: ['startup', 'standard', 'eternal'] },
+      include: ['restrictions'],
+      sort: '-id',
+    });
 
     const cardIds = new Set();
     const formats = [];

--- a/app/templates/page/banlists.hbs
+++ b/app/templates/page/banlists.hbs
@@ -41,7 +41,7 @@
                 >Null Signal Games' Supported Formats page</a>
                 for more information.</p>
               <Banlist::Tabs
-                @formats={{@model}}
+                @formats={{@model.formats}}
                 @selectedFormat={{this.format}}
                 @query={{this.search}}
               />


### PR DESCRIPTION
Heavily edit the banlist route to format the data nicely for the display.

I went this route to start rather than heavily editing the API, but I think more can be done.

Reduced this all down to 2 network calls.

<img width="791" alt="Screenshot 2023-10-17 at 8 16 16 PM" src="https://github.com/NetrunnerDB/NRDBv2/assets/396562/7310a105-f06e-4ba2-9d8c-cdbe91dde07c">
<img width="797" alt="Screenshot 2023-10-17 at 8 16 35 PM" src="https://github.com/NetrunnerDB/NRDBv2/assets/396562/8e54aff3-6929-4975-beba-3ef1de8fb8f2">
<img width="783" alt="Screenshot 2023-10-17 at 8 16 57 PM" src="https://github.com/NetrunnerDB/NRDBv2/assets/396562/4474947f-815e-4501-959d-a459a02d00fd">
<img width="787" alt="Screenshot 2023-10-17 at 8 17 14 PM" src="https://github.com/NetrunnerDB/NRDBv2/assets/396562/6a3f6ddc-9fbd-40b8-9f19-a1a43395e676">
<img width="785" alt="Screenshot 2023-10-17 at 8 17 35 PM" src="https://github.com/NetrunnerDB/NRDBv2/assets/396562/98978712-f1cc-42e3-bde7-6233d39c5564">
