### PR TITLE
Basic search form. Update search fields to use this.

### DIFF
--- a/app/components/home/sidebar.gjs
+++ b/app/components/home/sidebar.gjs
@@ -15,7 +15,7 @@ export default class SidebarComponent extends Component {
     // Reset the search bar.
     e.target.query.value = '';
 
-    this.router.transitionTo('page.advanced-search', {
+    this.router.transitionTo('page.basic-search', {
       queryParams: { query: query },
     });
   }

--- a/app/components/page/navbar.gjs
+++ b/app/components/page/navbar.gjs
@@ -33,7 +33,7 @@ export default class PageNavbarComponent extends Component {
     // Reset the search bar.
     e.target.query.value = '';
 
-    this.router.transitionTo('page.advanced-search', {
+    this.router.transitionTo('page.basic-search', {
       queryParams: { query: query },
     });
   }

--- a/app/components/search/basic-search-form.gjs
+++ b/app/components/search/basic-search-form.gjs
@@ -1,0 +1,151 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { fn } from '@ember/helper';
+import { tracked } from '@glimmer/tracking';
+import BsForm from 'ember-bootstrap/components/bs-form';
+import PowerSelect from 'ember-power-select/components/power-select';
+
+export default class SearchFormComponent extends Component {
+  @service router;
+  @tracked searchParams;
+
+  // TODO(plural): sort params to aid caching.
+  constructor() {
+    super(...arguments);
+    this.searchParams = this.args.searchParams;
+    let p = this.searchParams;
+    let a = this.args.searchParams;
+
+    p.display = this.single(a.display, this.displayOptions);
+    p.max_records = this.single(a.max_records, this.maxRecords);
+  }
+
+  // Provide value for single select element.
+  single(param, objects) {
+    if (!param) {
+      return null;
+    }
+    let id = String(param).toLowerCase();
+    let matches = objects.filter((x) => x.id == id);
+    if (matches.length > 0) {
+      return matches[0];
+    }
+    return null;
+  }
+
+  // Provide values for multi-select element.
+  multi(param, objects) {
+    if (!param) {
+      return [];
+    }
+    let ids = param.toLowerCase().split?.(',');
+    return objects.filter((x) => ids.includes(x.id));
+  }
+
+  displayOptions = [
+    { id: 'checklist', name: 'Checklist' },
+    { id: 'full', name: 'Full Card' },
+    { id: 'images', name: 'Image Only' },
+    { id: 'text', name: 'Text Only' },
+  ];
+  maxRecords = [25, 50, 100, 250, 500, 1000, 5000].map((x) => {
+    return { id: x, name: x };
+  });
+
+  getText(p, q, field) {
+    if (p[field] && p[field].trim().length > 0) {
+      q[field] = p[field].trim();
+    } else {
+      q[field] = null;
+    }
+  }
+  getSelect(p, q, field) {
+    if (p[field]) {
+      q[field] = p[field].id;
+    } else {
+      q[field] = null;
+    }
+  }
+
+  getMultiSelect(p, q, field) {
+    if (p[field] && p[field].length != 0) {
+      q[field] = p[field].map((x) => x.id);
+    } else {
+      q[field] = null;
+    }
+  }
+
+  @action doSearch() {
+    let p = this.searchParams;
+    let q = {};
+
+    this.getSelect(p, q, 'display');
+    this.getSelect(p, q, 'max_records');
+    this.getText(p, q, 'query');
+
+    this.router.transitionTo(this.router.currentRouteName, {
+      queryParams: q,
+    });
+  }
+
+  <template>
+    <h1>Basic Search Form</h1>
+
+    <BsForm
+      @formLayout='vertical'
+      @onSubmit={{this.doSearch}}
+      @model={{this.searchParams}}
+      as |form|
+    >
+      <fieldset>
+        <div class='row'>
+          <div class='col-sm-12'>
+            <form.element
+              @controlType='textarea'
+              @label='Query'
+              @property='query'
+            />
+          </div>
+        </div>
+      </fieldset>
+
+      <div class='row'>
+        <div class='col-sm-3'>
+          <form.element @label='Num Records' @property='max_records' as |el|>
+            <PowerSelect
+              @options={{this.maxRecords}}
+              @selected={{this.searchParams.max_records}}
+              @triggerId={{el.id}}
+              @onFocus={{action.focus}}
+              @onChange={{fn (mut this.searchParams.max_records)}}
+              as |x|
+            >
+              {{x.name}}
+            </PowerSelect>
+          </form.element>
+        </div>
+        <div class='col-sm-3'>
+          <form.element @label='Display' @property='display' as |el|>
+            <PowerSelect
+              @options={{this.displayOptions}}
+              @selected={{this.searchParams.display}}
+              @triggerId={{el.id}}
+              @onFocus={{action.focus}}
+              @onChange={{fn (mut this.searchParams.display)}}
+              as |x|
+            >
+              View as
+              {{x.name}}
+            </PowerSelect>
+          </form.element>
+        </div>
+      </div>
+      <div class='row'>
+        <div class='col-sm-2'>
+          <form.submitButton>Submit</form.submitButton>
+        </div>
+      </div>
+    </BsForm>
+  </template>
+}

--- a/app/components/search/search-form.gjs
+++ b/app/components/search/search-form.gjs
@@ -175,7 +175,7 @@ export default class SearchFormComponent extends Component {
   }
 
   <template>
-    <h1>Search Form</h1>
+    <h1>Advanced Search Form</h1>
 
     {{#if @searchParams.query}}
       <p>Free form query is: <strong>{{@searchParams.query}}</strong></p>

--- a/app/controllers/page/basic-search.js
+++ b/app/controllers/page/basic-search.js
@@ -1,0 +1,10 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+
+export default class BasicSearchController extends Controller {
+  queryParams = ['display', 'max_records', 'query'];
+
+  @tracked display = 'checklist';
+  @tracked query = '';
+  @tracked max_records = 100;
+}

--- a/app/router.js
+++ b/app/router.js
@@ -21,6 +21,7 @@ Router.map(function () {
   this.route('page', function () {
     this.route('advanced-search');
     this.route('banlists');
+    this.route('basic-search');
     this.route('card', { path: '/card/:id' });
     this.route('cycle', { path: '/cycle/:id' });
     this.route('cycles');

--- a/app/routes/page/basic-search.js
+++ b/app/routes/page/basic-search.js
@@ -14,21 +14,21 @@ export default class PageBasicSearchRoute extends Route {
   async model(params) {
     if (params.query) {
       return RSVP.hash({
+        display: 'checklist',
+        max_records: 100,
         printings: this.store.query('printing', {
           filter: { search: params.query },
           include: ['card_set', 'card_type', 'faction'],
           page: { limit: params.max_records || 100 },
         }),
-        searchParams: {
-          display: 'checklist',
-          max_records: 100,
-          query: params.query,
-        },
+        query: params.query,
       });
     } else {
       return RSVP.hash({
+        display: 'checklist',
+        max_records: 100,
         printings: [],
-        searchParams: { display: 'checklist', max_records: 100 },
+        query: '',
       });
     }
   }

--- a/app/routes/page/basic-search.js
+++ b/app/routes/page/basic-search.js
@@ -1,0 +1,35 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import RSVP from 'rsvp';
+
+export default class PageBasicSearchRoute extends Route {
+  @service store;
+
+  queryParams = {
+    display: { refreshModel: true },
+    max_records: { refreshModel: true },
+    query: { refreshModel: true },
+  };
+
+  async model(params) {
+    if (params.query) {
+      return RSVP.hash({
+        printings: this.store.query('printing', {
+          filter: { search: params.query },
+          include: ['card_set', 'card_type', 'faction'],
+          page: { limit: params.max_records || 100 },
+        }),
+        searchParams: {
+          display: 'checklist',
+          max_records: 100,
+          query: params.query,
+        },
+      });
+    } else {
+      return RSVP.hash({
+        printings: [],
+        searchParams: { display: 'checklist', max_records: 100 },
+      });
+    }
+  }
+}

--- a/app/templates/page/basic-search.hbs
+++ b/app/templates/page/basic-search.hbs
@@ -7,7 +7,9 @@
         <div class="card-body d-flex flex-column flex-lg-row justify-content-between" >
           <div class="container" id="basic-search">
             <Search::BasicSearchForm
-              @searchParams={{@model.searchParams}}
+              @query={{@model.query}}
+              @max_records={{@model.max_records}}
+              @display={{@model.display}}
             />
           </div>
         </div>

--- a/app/templates/page/basic-search.hbs
+++ b/app/templates/page/basic-search.hbs
@@ -1,0 +1,32 @@
+{{page-title "Basic Search"}}
+
+<div class="container">
+  <div class="row">
+    <div class="col-12 d-flex flex-row flex-sm-column my-2">
+      <div class="card border-0 flex-grow-1" id="nav-main-content">
+        <div class="card-body d-flex flex-column flex-lg-row justify-content-between" >
+          <div class="container" id="basic-search">
+            <Search::BasicSearchForm
+              @searchParams={{@model.searchParams}}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {{#if @model.printings.length }}
+  <div class="row">
+    <div class="col-12 d-flex flex-row flex-sm-column my-2">
+      <div class="card border-0 flex-grow-1">
+        <div class="card-body d-flex flex-column flex-lg-row justify-content-between">
+          <div class="container" id="cycle-card-list">
+            <h1>Search Results</h1>
+            <CardLists @printings={{@model.printings}} @display="{{this.display}}" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  {{/if}}
+</div>


### PR DESCRIPTION
This works except for one thing.

When you are on the results page, if you use the search form in navbar.gjs, the results change, but the query in the basic search form's text box does not.

I don't think we want to keep this long term, but a place for raw queries is nice until we get a fancier conditional query builder built.