### PR TITLE
Cycle and Set card list improvements.

### DIFF
--- a/app/routes/cycle.js
+++ b/app/routes/cycle.js
@@ -6,18 +6,14 @@ export default class CyclesRoute extends Route {
   @service store;
 
   async model(params) {
-    let cardCycle = this.store.findRecord('cardCycle', params.id);
+    let cardCycle = this.store.findRecord('cardCycle', params.id, {
+      include: ['printings', 'printings.card_type']
+    });
 
     let allCycles = await this.store
       .query('cardCycle', {
         sort: 'date_release',
-      })
-      // Temporary measure to filter out non-cycles until that data is added to the API
-      .then((cycles) =>
-        cycles.filter((cycle) => {
-          return cycle.cardSets.length > 1;
-        }),
-      );
+      });
 
     let cycleIndex = allCycles.findIndex((cycle) => cycle.id == params.id);
     let nextCycle =

--- a/app/routes/cycle.js
+++ b/app/routes/cycle.js
@@ -7,13 +7,12 @@ export default class CyclesRoute extends Route {
 
   async model(params) {
     let cardCycle = this.store.findRecord('cardCycle', params.id, {
-      include: ['printings', 'printings.card_type']
+      include: ['printings', 'printings.card_type'],
     });
 
-    let allCycles = await this.store
-      .query('cardCycle', {
-        sort: 'date_release',
-      });
+    let allCycles = await this.store.query('cardCycle', {
+      sort: 'date_release',
+    });
 
     let cycleIndex = allCycles.findIndex((cycle) => cycle.id == params.id);
     let nextCycle =

--- a/app/routes/set.js
+++ b/app/routes/set.js
@@ -7,7 +7,7 @@ export default class SetsRoute extends Route {
 
   async model(params) {
     let cardSet = this.store.findRecord('cardSet', params.id, {
-      include: ['printings', 'printings.card_type']
+      include: ['printings', 'printings.card_type'],
     });
 
     let allSets = await this.store.query('cardSet', {

--- a/app/routes/set.js
+++ b/app/routes/set.js
@@ -6,7 +6,9 @@ export default class SetsRoute extends Route {
   @service store;
 
   async model(params) {
-    let cardSet = this.store.findRecord('cardSet', params.id);
+    let cardSet = this.store.findRecord('cardSet', params.id, {
+      include: ['printings', 'printings.card_type']
+    });
 
     let allSets = await this.store.query('cardSet', {
       sort: 'date_release',

--- a/app/templates/set.hbs
+++ b/app/templates/set.hbs
@@ -32,7 +32,7 @@
   </Titlebar>
 
   <div class="container">
-    <Card::List @printings={{@model.cardSet.printings}} />
+    <Card::List @printings={{sort-by "position" @model.cardSet.printings}} />
   </div>
 
 </main>


### PR DESCRIPTION
Include printings and card type to reduce extra async loads on cycle and set card list pages.

Fix cycle navigation.
<img width="1337" alt="Screenshot 2024-11-25 at 10 57 18 PM" src="https://github.com/user-attachments/assets/032df507-7d89-4255-8795-7f6fb673b1b4">

Sort set printings by position to match the cycle page.
<img width="1325" alt="Screenshot 2024-11-25 at 10 56 56 PM" src="https://github.com/user-attachments/assets/c059a1bc-2ecc-444f-aff0-2b597b2ba1a5">

