### PR TITLE
Fix card cycle icon in card list textbox component.

### DIFF
--- a/app/components/card/text-box.gjs
+++ b/app/components/card/text-box.gjs
@@ -67,7 +67,7 @@ function backgroundImage(image) {
         </span>
         {{TruncateFaction @printing.faction.name}}
         •
-        <Icon @icon={{@printing.cardSetId}} />
+        <Icon @icon={{@printing.cardCycleId}} />
         <LinkTo
           @route='set'
           @model='{{@printing.cardSet.id}}'


### PR DESCRIPTION
This was previously using the set id, but sets don't have icons.

<img width="422" alt="Screenshot 2024-11-25 at 10 58 30 PM" src="https://github.com/user-attachments/assets/f8da40a4-ac20-4e23-9999-ad280ba3791d">
