### PR TITLE
Include the actual instructions to install and run in development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ You will need the following things properly installed on your computer.
 
 ## Installation
 
-# TODO corething enable
-
 - `git clone <repository-url>` this repository
 - `cd NRDBv2`
 - `corepack enable` (see [here](https://yarnpkg.com/getting-started/install) for an explanation, this is required by yarn)

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ You will need the following things properly installed on your computer.
 
 # TODO corething enable
 
-- `$ git clone <repository-url>` this repository
-- `$ cd NRDBv2`
-- `$ corepack enable` (see [here](https://yarnpkg.com/getting-started/install) for an explanation, this is required by yarn)
-- `$ yarn install`
+- `git clone <repository-url>` this repository
+- `cd NRDBv2`
+- `corepack enable` (see [here](https://yarnpkg.com/getting-started/install) for an explanation, this is required by yarn)
+- `yarn install`
 
 ## Running / Development
 
-- `$ yarn start`
+- `yarn start`
 - Visit your app at [http://localhost:4200](http://localhost:4200).
 - Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
-# netrunnerdb
+# NetrunnerDB v2
 
-This README outlines the details of collaborating on this Ember application.
-A short introduction of this app could easily go here.
+This repository contains the second iteration of NetrunnerDB, the card database for Netrunner. It is written using Ember.js.
 
 ## Prerequisites
 
 You will need the following things properly installed on your computer.
 
 - [Git](https://git-scm.com/)
-- [Node.js](https://nodejs.org/)
-- [Yarn](https://yarnpkg.com/)
-- [Ember CLI](https://cli.emberjs.com/release/)
-- [Google Chrome](https://google.com/chrome/)
+- [Node.js](https://nodejs.org/) version 18 or 22
+- A browser
+- [netrunner-api-server](https://github.com/NetrunnerDB/netrunnerdb-api-server) (which comes with its own set of dependencies) cloned in the same parent folder as this repository
 
 ## Installation
 
-- `git clone <repository-url>` this repository
-- `cd netrunnerdb`
-- `yarn install`
+# TODO corething enable
+
+- `$ git clone <repository-url>` this repository
+- `$ cd NRDBv2`
+- `$ corepack enable` (see [here](https://yarnpkg.com/getting-started/install) for an explanation, this is required by yarn)
+- `$ yarn install`
 
 ## Running / Development
 
-- `ember serve`
+- `$ yarn start`
 - Visit your app at [http://localhost:4200](http://localhost:4200).
 - Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
 
@@ -43,6 +44,8 @@ Make use of the many generators for code, try `ember help generate` for more det
 
 - `ember build` (development)
 - `ember build --environment production` (production)
+
+`yarn build` runs the production version of `ember build`.
 
 ### Deploying
 

--- a/package.json
+++ b/package.json
@@ -100,5 +100,6 @@
   },
   "dependencies": {
     "graphql": "^16.9.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Includes some changes to the README to make it more accurate (the existing one seemed like it was ember's default), as well as locking the yarn version in package.json.