### PR TITLE
Properly link to neutral runner faction page.

### DIFF
--- a/app/templates/factions.hbs
+++ b/app/templates/factions.hbs
@@ -58,7 +58,7 @@
           </LinkTo>
         </div>
         <div class="col">
-          <LinkTo @route="faction" @model="shaper">
+          <LinkTo @route="faction" @model="neutral_runner">
             <div class="card">
               <img
                 alt="Shaper"


### PR DESCRIPTION
This was linking to shaper before.